### PR TITLE
Branch unordered tags

### DIFF
--- a/src/main/java/seedu/command/AddCommand.java
+++ b/src/main/java/seedu/command/AddCommand.java
@@ -1,6 +1,7 @@
 package seedu.command;
 
 import seedu.equipment.DuplicateSerialNumber;
+import seedu.equipment.Equipment;
 import seedu.equipment.EquipmentType;
 
 import java.util.ArrayList;
@@ -8,8 +9,7 @@ import java.util.ArrayList;
 /**
  * Subclass of Command. Handles adding of equipment to equipmentInventory.
  */
-public class AddCommand extends Command {
-    private final ArrayList<String> commandStrings;
+public class AddCommand extends ModificationCommand {
     public static final String COMMAND_WORD = "add";
     public static final String COMMAND_DESCRIPTION = ": Adds a Equipment to the equipmentInventory. "
             + "Parameters: n/ITEM_NAME s/SERIAL_NUMBER t/TYPE c/COST pf/PURCHASED_FROM pd/PURCHASED_DATE"
@@ -17,6 +17,8 @@ public class AddCommand extends Command {
             + "Example: "
             + "add n/SpeakerB s/S1404115ASF t/Speaker c/1000 pf/Loud_Technologies pd/2022-02-23";
     public static final String DUPLICATE_ITEM_ERROR = "There is already an item with this serial number: %1$s";
+    public static final String ATTRIBUTE_NOT_SET_ERROR = "Unable to add. " +
+            "One or more than one of the attributes of Equipment is not specified.";
 
     /**
      * constructor for AddCommand. Initialises successMessage and usageReminder from Command
@@ -24,9 +26,11 @@ public class AddCommand extends Command {
      * @param commandStrings parsed user input which contains details of equipment to be added
      */
     public AddCommand(ArrayList<String> commandStrings) {
-        this.commandStrings = commandStrings;
+        super(commandStrings);
         successMessage = "Equipment successfully added: %1$s, serial number %2$s";
         usageReminder = COMMAND_WORD + COMMAND_DESCRIPTION;
+
+        prepareModification();
     }
 
     /**
@@ -35,6 +39,10 @@ public class AddCommand extends Command {
      * @return CommandResult with message from execution of this command
      */
     public CommandResult execute() {
+        if (!checkAttributes()) {
+            return new CommandResult(ATTRIBUTE_NOT_SET_ERROR);
+        }
+
         try {
             addEquipment(commandStrings);
         } catch (DuplicateSerialNumber e) {
@@ -54,13 +62,23 @@ public class AddCommand extends Command {
      * @param userInput ArrayList of String which contains the individual attributes of the equipment to be added
      */
     public void addEquipment(ArrayList<String> userInput) throws DuplicateSerialNumber {
-        String equipmentName = userInput.get(0);
-        String serialNumber = userInput.get(1);
-        EquipmentType type = EquipmentType.valueOf(userInput.get(2));
-        double cost = Double.parseDouble(userInput.get(3));
-        String purchasedFrom = userInput.get(4);
-        String purchasedDate = userInput.get(5);
+        EquipmentType type = EquipmentType.valueOf(this.type);
+        double cost = Double.parseDouble(this.cost);
 
-        equipmentManager.addEquipment(equipmentName, serialNumber, type, cost, purchasedFrom, purchasedDate);
+        Equipment newEquipment = new Equipment(equipmentName, serialNumber, type, cost, purchasedFrom, purchasedDate);
+        equipmentManager.addEquipment(newEquipment);
+    }
+
+    /**
+     * Checks if all the attributes of Equipment to be added have been set. There should be no null values.
+     * @return boolean to indicate whether all attributes are set.
+     */
+    public boolean checkAttributes() {
+        if (equipmentName == null || serialNumber == null || type == null || cost == null ||
+                purchasedFrom == null || purchasedDate == null) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/seedu/command/ModificationCommand.java
+++ b/src/main/java/seedu/command/ModificationCommand.java
@@ -2,6 +2,9 @@ package seedu.command;
 
 import java.util.ArrayList;
 
+/**
+ * Abstract class acting as parent class to AddCommand and UpdateCommand which have use for the same prepareModification method.
+ */
 public abstract class ModificationCommand extends Command {
     protected final ArrayList<String> commandStrings;
     protected String serialNumber;

--- a/src/main/java/seedu/command/ModificationCommand.java
+++ b/src/main/java/seedu/command/ModificationCommand.java
@@ -1,0 +1,83 @@
+package seedu.command;
+
+import java.util.ArrayList;
+
+public abstract class ModificationCommand extends Command {
+    protected final ArrayList<String> commandStrings;
+    protected String serialNumber;
+    protected String equipmentName = null;
+    protected String purchasedDate = null;
+    protected String type = null;
+    protected String purchasedFrom = null;
+    protected String cost = null;
+
+    public ModificationCommand(ArrayList<String> commandStrings) {
+        this.commandStrings = commandStrings;
+    }
+
+    public abstract CommandResult execute();
+
+    public void setSerialNumber(String serialNumber) {
+        this.serialNumber = serialNumber;
+    }
+
+    public void setEquipmentName(String equipmentName) {
+        this.equipmentName = equipmentName;
+    }
+
+    public void setPurchasedDate(String purchasedDate) {
+        this.purchasedDate = purchasedDate;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setPurchasedFrom(String purchasedFrom) {
+        this.purchasedFrom = purchasedFrom;
+    }
+
+    public void setCost(String cost) {
+        this.cost = cost;
+    }
+
+    /**
+     * Set up UpdateCommand with arguments required to update a given item
+     * <p>
+     * Should multiple arguments specifying the same argument parameter (e.g. 'c/1000' and 'c/2000') be given,
+     * the previous arguments passed in will be overwritten by the most recent parameter ('c/2000' in example).
+     */
+    protected void prepareModification() throws AssertionError {
+        for (String s : commandStrings) {
+            int delimiterPos = s.indexOf('/');
+            // the case where delimiterPos = -1 is impossible as
+            // ARGUMENT_FORMAT and ARGUMENT_TRAILING_FORMAT regex requires a '/'
+            assert delimiterPos != -1 : "Each args will need to include minimally a '/' to split arg and value upon";
+            String argType = s.substring(0, delimiterPos);
+            String argValue = s.substring(delimiterPos + 1);
+            switch (argType) {
+            case "n":
+                setEquipmentName(argValue);
+                break;
+            case "pd":
+                setPurchasedDate(argValue);
+                break;
+            case "t":
+                setType(argValue);
+                break;
+            case "pf":
+                setPurchasedFrom(argValue);
+                break;
+            case "c":
+                setCost(argValue);
+                break;
+            case "s":
+                setSerialNumber(argValue);
+                break;
+            default:
+                System.out.println("`" + argValue + "` not accepted for type " + argType + ": Unrecognised Tag");
+            }
+        }
+
+    }
+}

--- a/src/main/java/seedu/command/ModificationCommand.java
+++ b/src/main/java/seedu/command/ModificationCommand.java
@@ -5,7 +5,9 @@ import java.util.ArrayList;
 /**
  * Abstract class acting as parent class to AddCommand and UpdateCommand which have use for the same prepareModification method.
  */
-public abstract class ModificationCommand extends Command {
+public class ModificationCommand extends Command {
+    public final String IMPLEMENTED_BY_CHILD = "Execute method for Modification should be implemented by " +
+            "child classes AddCommand and UpdateCommand";
     protected final ArrayList<String> commandStrings;
     protected String serialNumber;
     protected String equipmentName = null;
@@ -18,7 +20,9 @@ public abstract class ModificationCommand extends Command {
         this.commandStrings = commandStrings;
     }
 
-    public abstract CommandResult execute();
+    public CommandResult execute() {
+        return new CommandResult(IMPLEMENTED_BY_CHILD);
+    }
 
     public void setSerialNumber(String serialNumber) {
         this.serialNumber = serialNumber;

--- a/src/main/java/seedu/command/ModificationCommand.java
+++ b/src/main/java/seedu/command/ModificationCommand.java
@@ -45,7 +45,7 @@ public abstract class ModificationCommand extends Command {
     }
 
     /**
-     * Set up UpdateCommand with arguments required to update a given item
+     * Set up ModificationCommand with arguments required to update a given item
      * <p>
      * Should multiple arguments specifying the same argument parameter (e.g. 'c/1000' and 'c/2000') be given,
      * the previous arguments passed in will be overwritten by the most recent parameter ('c/2000' in example).

--- a/src/main/java/seedu/command/UpdateCommand.java
+++ b/src/main/java/seedu/command/UpdateCommand.java
@@ -12,6 +12,7 @@ public class UpdateCommand extends Command {
             + "Parameters: s/SERIAL_NUMBER" + System.lineSeparator()
             + "Example: "
             + "update s/SM57-1";
+    public static final String UPDATE_FAILURE_MESSAGE = "Equipment was not updated successfully.";
     private String serialNumber;
 
     private String updateName = null;
@@ -40,7 +41,9 @@ public class UpdateCommand extends Command {
         }
 
         ArrayList<Pair<String, String>> updatePairs = generateUpdatePairs();
-        equipmentManager.updateEquipment(serialNumber, updatePairs);
+        if(!equipmentManager.updateEquipment(serialNumber, updatePairs)){
+            return new CommandResult(UPDATE_FAILURE_MESSAGE);
+        }
 
         return new CommandResult(String.format(successMessage, serialNumber, generateUpdateString()));
     }

--- a/src/main/java/seedu/command/UpdateCommand.java
+++ b/src/main/java/seedu/command/UpdateCommand.java
@@ -5,36 +5,29 @@ import seedu.Pair;
 import java.util.ArrayList;
 import java.util.Objects;
 
-public class UpdateCommand extends Command {
-    private final ArrayList<String> commandStrings;
+public class UpdateCommand extends ModificationCommand {
+    public static final String UPDATE_FAILURE_MESSAGE = "Equipment was not updated successfully.";
     public static final String COMMAND_WORD = "update";
     public static final String COMMAND_DESCRIPTION = ": Updates the equipment with the specified serial number. "
             + "Parameters: s/SERIAL_NUMBER" + System.lineSeparator()
             + "Example: "
             + "update s/SM57-1";
-    public static final String UPDATE_FAILURE_MESSAGE = "Equipment was not updated successfully.";
-    private String serialNumber;
-
-    private String updateName = null;
-    private String purchaseDate = null;
-    private String type = null;
-    private String purchaseFrom = null;
-    private String cost = null;
 
 
     /**
      * constructor for UpdateCommand. Initialises successMessage and usageReminder from Command
      */
     public UpdateCommand(ArrayList<String> commandStrings) {
-        this.commandStrings = commandStrings;
+        super(commandStrings);
         successMessage = "Equipment successfully updated for serial number %1$s,"
                 + System.lineSeparator()
                 + "Updated details are: %2$s";
         usageReminder = COMMAND_WORD + COMMAND_DESCRIPTION;
 
-        prepareUpdate();
+        prepareModification();
     }
 
+    @Override
     public CommandResult execute() {
         if (getSerialNumber() == null) {
             return new CommandResult(MISSING_SERIAL_NUMBER);
@@ -52,34 +45,10 @@ public class UpdateCommand extends Command {
         return serialNumber;
     }
 
-    public void setSerialNumber(String serialNumber) {
-        this.serialNumber = serialNumber;
-    }
-
-    public void setUpdateName(String updateName) {
-        this.updateName = updateName;
-    }
-
-    public void setPurchaseDate(String purchaseDate) {
-        this.purchaseDate = purchaseDate;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    public void setPurchaseFrom(String purchaseFrom) {
-        this.purchaseFrom = purchaseFrom;
-    }
-
-    public void setCost(String cost) {
-        this.cost = cost;
-    }
-
     public ArrayList<Pair<String, String>> generateUpdatePairs() {
         ArrayList<Pair<String, String>> pairs = new ArrayList<>();
-        if (updateName != null) {
-            pairs.add(new Pair<>("itemName", updateName));
+        if (equipmentName != null) {
+            pairs.add(new Pair<>("itemName", equipmentName));
         }
         if (type != null) {
             pairs.add(new Pair<>("type", type));
@@ -87,11 +56,11 @@ public class UpdateCommand extends Command {
         if (cost != null) {
             pairs.add(new Pair<>("cost", cost));
         }
-        if (purchaseDate != null) {
-            pairs.add(new Pair<>("purchasedDate", purchaseDate));
+        if (purchasedDate != null) {
+            pairs.add(new Pair<>("purchasedDate", purchasedDate));
         }
-        if (purchaseFrom != null) {
-            pairs.add(new Pair<>("purchasedFrom", purchaseFrom));
+        if (purchasedFrom != null) {
+            pairs.add(new Pair<>("purchasedFrom", purchasedFrom));
         }
 
         return pairs;
@@ -99,8 +68,8 @@ public class UpdateCommand extends Command {
 
     public String generateUpdateString() {
         String updateDetails = "";
-        if (updateName != null) {
-            updateDetails = updateDetails + System.lineSeparator() + "New name: " + updateName;
+        if (equipmentName != null) {
+            updateDetails = updateDetails + System.lineSeparator() + "New name: " + equipmentName;
         }
         if (type != null) {
             updateDetails = updateDetails + System.lineSeparator() + "New type: " + type;
@@ -108,55 +77,14 @@ public class UpdateCommand extends Command {
         if (cost != null) {
             updateDetails = updateDetails + System.lineSeparator() + "New cost: " + cost;
         }
-        if (purchaseDate != null) {
-            updateDetails = updateDetails + System.lineSeparator() + "New purchase date: " + purchaseDate;
+        if (purchasedDate != null) {
+            updateDetails = updateDetails + System.lineSeparator() + "New purchase date: " + purchasedDate;
         }
-        if (purchaseFrom != null) {
-            updateDetails = updateDetails + System.lineSeparator() + "New purchased from: " + purchaseFrom;
+        if (purchasedFrom != null) {
+            updateDetails = updateDetails + System.lineSeparator() + "New purchased from: " + purchasedFrom;
         }
 
         return updateDetails;
-    }
-
-    /**
-     * Set up UpdateCommand with arguments required to update a given item
-     * <p>
-     * Should multiple arguments specifying the same argument parameter (e.g. 'c/1000' and 'c/2000') be given,
-     * the previous arguments passed in will be overwritten by the most recent parameter ('c/2000' in example).
-     *
-     */
-    protected void prepareUpdate() throws AssertionError {
-        for (String s : commandStrings) {
-            int delimiterPos = s.indexOf('/');
-            // the case where delimiterPos = -1 is impossible as
-            // ARGUMENT_FORMAT and ARGUMENT_TRAILING_FORMAT regex requires a '/'
-            assert delimiterPos != -1 : "Each args will need to include minimally a '/' to split arg and value upon";
-            String argType = s.substring(0, delimiterPos);
-            String argValue = s.substring(delimiterPos + 1);
-            switch (argType) {
-            case "n":
-                setUpdateName(argValue);
-                break;
-            case "pd":
-                setPurchaseDate(argValue);
-                break;
-            case "t":
-                setType(argValue);
-                break;
-            case "pf":
-                setPurchaseFrom(argValue);
-                break;
-            case "c":
-                setCost(argValue);
-                break;
-            case "s":
-                setSerialNumber(argValue);
-                break;
-            default:
-                System.out.println("`" + argValue + "` not updated for type " + argType + ": Unrecognised Tag");
-            }
-        }
-
     }
 
     @Override
@@ -169,15 +97,15 @@ public class UpdateCommand extends Command {
         }
         UpdateCommand that = (UpdateCommand) o;
         return serialNumber.equals(that.serialNumber) &&
-                Objects.equals(updateName, that.updateName) &&
-                Objects.equals(purchaseDate, that.purchaseDate) &&
+                Objects.equals(equipmentName, that.equipmentName) &&
+                Objects.equals(purchasedDate, that.purchasedDate) &&
                 Objects.equals(type, that.type) &&
-                Objects.equals(purchaseFrom, that.purchaseFrom) &&
+                Objects.equals(purchasedFrom, that.purchasedFrom) &&
                 Objects.equals(cost, that.cost);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(serialNumber, updateName, purchaseDate, type, purchaseFrom, cost);
+        return Objects.hash(serialNumber, equipmentName, purchasedDate, type, purchasedFrom, cost);
     }
 }

--- a/src/test/java/seedu/command/AddCommandTest.java
+++ b/src/test/java/seedu/command/AddCommandTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class AddCommandTest {
     AddCommand addCommand;
     ArrayList<String> userInput = new ArrayList<>(
-            Arrays.asList("Speaker B", "S1404115ASF", "SPEAKER", "1000", "Loud Technologies", "2022-02-23")
+            Arrays.asList("n/Speaker B", "s/S1404115ASF", "t/SPEAKER", "c/1000", "pf/Loud Technologies", "pd/2022-02-23")
     );
 
     @Test
@@ -40,7 +40,7 @@ class AddCommandTest {
     @Test
     void execute_incorrectCostFormat_exceptionThrown() {
         addCommand = new AddCommand(new ArrayList<>(
-                Arrays.asList("Speaker B", "S1404115ASF", "SPEAKER", "$1000", "Loud Technologies", "2022-02-23")
+                Arrays.asList("n/Speaker B", "s/S1404115ASF", "t/SPEAKER", "c/$1000", "pf/Loud Technologies", "pd/2022-02-23")
         ));
 
         CommandResult expectedResult = new CommandResult("Please enter numbers only for cost and omit symbols");
@@ -51,7 +51,7 @@ class AddCommandTest {
     @Test
     void execute_incorrectEnumType_exceptionThrown() {
         addCommand = new AddCommand(new ArrayList<>(
-                Arrays.asList("Speaker B", "S1404115ASF", "SPEAKERS", "1000", "Loud Technologies", "2022-02-23")
+                Arrays.asList("n/Speaker B", "s/S1404115ASF", "t/SPEAKERS", "c/1000", "pf/Loud Technologies", "pd/2022-02-23")
         ));
         addCommand.setEquipmentManager(new EquipmentManager());
         EquipmentManager equipmentManager = addCommand.equipmentManager;
@@ -79,5 +79,23 @@ class AddCommandTest {
 
         assertEquals(equipmentListOriginalSize + 1, equipmentManager.getEquipmentList().size());
         assertEquals(expectedEquipment, actualEquipment);
+    }
+
+    @Test
+    void checkAttributes_allAttributesSet_true() {
+        addCommand = new AddCommand(userInput);
+        boolean actualResult = addCommand.checkAttributes();
+
+        assertEquals(true, actualResult);
+    }
+
+    @Test
+    void checkAttributes_oneOrMoreNulls_false() {
+        addCommand = new AddCommand(new ArrayList<>(
+                Arrays.asList("n/Speaker B", "s/S1404115ASF", "t/SPEAKER", "pf/Loud Technologies")
+        ));
+        boolean actualResult = addCommand.checkAttributes();
+
+        assertEquals(false, actualResult);
     }
 }

--- a/src/test/java/seedu/command/AddCommandTest.java
+++ b/src/test/java/seedu/command/AddCommandTest.java
@@ -86,7 +86,7 @@ class AddCommandTest {
         addCommand = new AddCommand(userInput);
         boolean actualResult = addCommand.checkAttributes();
 
-        assertEquals(true, actualResult);
+        assertTrue(actualResult);
     }
 
     @Test
@@ -96,6 +96,6 @@ class AddCommandTest {
         ));
         boolean actualResult = addCommand.checkAttributes();
 
-        assertEquals(false, actualResult);
+        assertFalse(actualResult);
     }
 }

--- a/src/test/java/seedu/command/ModificationCommandTest.java
+++ b/src/test/java/seedu/command/ModificationCommandTest.java
@@ -1,0 +1,46 @@
+package seedu.command;
+
+import org.junit.jupiter.api.Test;
+import seedu.parser.IncompleteCommandException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ModificationCommandTest {
+    ModificationCommand modificationCommand;
+
+    @Test
+    void prepareModification_missingSlashDelimiter_assertionErrorThrown() throws AssertionError {
+        ArrayList<String> testArrayList = new ArrayList<>(Collections.singleton("thiswillnotwork"));
+        try {
+            modificationCommand = new ModificationCommand(testArrayList);
+            modificationCommand.prepareModification();
+        } catch (AssertionError error) {
+            assertEquals("Each args will need to include minimally a '/' to split arg and value upon", error.getMessage());
+        }
+    }
+
+    @Test
+    void prepareModification_missingSerialNumber_exceptionThrown() throws IncompleteCommandException {
+        ArrayList<String> testArrayList = new ArrayList<>(Arrays.asList(
+                "n/Speaker B", "t/SPEAKER", "c/1000", "pf/Loud Technologies", "pd/2022-02-23"));
+        UpdateCommand updateCommand = new UpdateCommand(testArrayList);
+        CommandResult expectedResult = new CommandResult("Serial Number is required to run this command");
+        assertEquals(expectedResult, updateCommand.execute());
+    }
+
+    @Test
+    void prepareModification_mostRecentArgValueUsed_success() throws IncompleteCommandException {
+        ArrayList<String> testArrayList = new ArrayList<>(Arrays.asList(
+                "s/S1404115ASF", "n/Speaker B", "n/Speaker A"));
+        ModificationCommand expectedCommand = new ModificationCommand(new ArrayList<>(
+                Arrays.asList("s/S1404115ASF", "n/Speaker A")
+        ));
+        ModificationCommand actualCommand = new ModificationCommand(testArrayList);
+        actualCommand.prepareModification();
+        assertEquals(expectedCommand, actualCommand);
+    }
+}

--- a/src/test/java/seedu/command/UpdateCommandTest.java
+++ b/src/test/java/seedu/command/UpdateCommandTest.java
@@ -67,7 +67,7 @@ class UpdateCommandTest {
     }
 
     @Test
-    void prepareUpdate_missingSlashDelimiter_assertionErrorThrown() throws AssertionError {
+    void prepareModification_missingSlashDelimiter_assertionErrorThrown() throws AssertionError {
         ArrayList<String> testArrayList = new ArrayList<>(Collections.singleton("thiswillnotwork"));
         try {
             updateCommand = new UpdateCommand(testArrayList);
@@ -77,16 +77,16 @@ class UpdateCommandTest {
     }
 
     @Test
-    void prepareUpdate_missingSerialNumber_exceptionThrown() throws IncompleteCommandException {
+    void prepareModification_missingSerialNumber_exceptionThrown() throws IncompleteCommandException {
         ArrayList<String> testArrayList = new ArrayList<>(Arrays.asList(
-                "n/Speaker B", "t/Speaker", "c/1000", "pf/Loud Technologies", "pd/2022-02-23"));
+                "n/Speaker B", "t/SPEAKER", "c/1000", "pf/Loud Technologies", "pd/2022-02-23"));
         updateCommand = new UpdateCommand(testArrayList);
         CommandResult expectedResult = new CommandResult("Serial Number is required to run this command");
         assertEquals(expectedResult, updateCommand.execute());
     }
 
     @Test
-    void prepareUpdate_mostRecentArgValueUsed_success() throws IncompleteCommandException {
+    void prepareModification_mostRecentArgValueUsed_success() throws IncompleteCommandException {
         ArrayList<String> testArrayList = new ArrayList<>(Arrays.asList(
                 "s/S1404115ASF", "n/Speaker B", "n/Speaker A"));
         UpdateCommand expectedCommand = new UpdateCommand(new ArrayList<>(

--- a/src/test/java/seedu/command/UpdateCommandTest.java
+++ b/src/test/java/seedu/command/UpdateCommandTest.java
@@ -1,6 +1,5 @@
 package seedu.command;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import seedu.Pair;
@@ -8,7 +7,6 @@ import seedu.equipment.DuplicateSerialNumber;
 import seedu.equipment.EquipmentManager;
 import seedu.equipment.EquipmentType;
 import seedu.parser.IncompleteCommandException;
-import seedu.parser.Parser;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -95,7 +93,7 @@ class UpdateCommandTest {
                 Arrays.asList("s/S1404115ASF", "n/Speaker A")
         ));
         UpdateCommand actualCommand = new UpdateCommand(testArrayList);
-        actualCommand.prepareUpdate();
+        actualCommand.prepareModification();
         assertEquals(expectedCommand, actualCommand);
     }
 }

--- a/src/test/java/seedu/command/UpdateCommandTest.java
+++ b/src/test/java/seedu/command/UpdateCommandTest.java
@@ -66,34 +66,34 @@ class UpdateCommandTest {
         assertEquals(expectedResult, actualResult);
     }
 
-    @Test
-    void prepareModification_missingSlashDelimiter_assertionErrorThrown() throws AssertionError {
-        ArrayList<String> testArrayList = new ArrayList<>(Collections.singleton("thiswillnotwork"));
-        try {
-            updateCommand = new UpdateCommand(testArrayList);
-        } catch (AssertionError error) {
-            assertEquals("Each args will need to include minimally a '/' to split arg and value upon", error.getMessage());
-        }
-    }
-
-    @Test
-    void prepareModification_missingSerialNumber_exceptionThrown() throws IncompleteCommandException {
-        ArrayList<String> testArrayList = new ArrayList<>(Arrays.asList(
-                "n/Speaker B", "t/SPEAKER", "c/1000", "pf/Loud Technologies", "pd/2022-02-23"));
-        updateCommand = new UpdateCommand(testArrayList);
-        CommandResult expectedResult = new CommandResult("Serial Number is required to run this command");
-        assertEquals(expectedResult, updateCommand.execute());
-    }
-
-    @Test
-    void prepareModification_mostRecentArgValueUsed_success() throws IncompleteCommandException {
-        ArrayList<String> testArrayList = new ArrayList<>(Arrays.asList(
-                "s/S1404115ASF", "n/Speaker B", "n/Speaker A"));
-        UpdateCommand expectedCommand = new UpdateCommand(new ArrayList<>(
-                Arrays.asList("s/S1404115ASF", "n/Speaker A")
-        ));
-        UpdateCommand actualCommand = new UpdateCommand(testArrayList);
-        actualCommand.prepareModification();
-        assertEquals(expectedCommand, actualCommand);
-    }
+//    @Test
+//    void prepareModification_missingSlashDelimiter_assertionErrorThrown() throws AssertionError {
+//        ArrayList<String> testArrayList = new ArrayList<>(Collections.singleton("thiswillnotwork"));
+//        try {
+//            updateCommand = new UpdateCommand(testArrayList);
+//        } catch (AssertionError error) {
+//            assertEquals("Each args will need to include minimally a '/' to split arg and value upon", error.getMessage());
+//        }
+//    }
+//
+//    @Test
+//    void prepareModification_missingSerialNumber_exceptionThrown() throws IncompleteCommandException {
+//        ArrayList<String> testArrayList = new ArrayList<>(Arrays.asList(
+//                "n/Speaker B", "t/SPEAKER", "c/1000", "pf/Loud Technologies", "pd/2022-02-23"));
+//        updateCommand = new UpdateCommand(testArrayList);
+//        CommandResult expectedResult = new CommandResult("Serial Number is required to run this command");
+//        assertEquals(expectedResult, updateCommand.execute());
+//    }
+//
+//    @Test
+//    void prepareModification_mostRecentArgValueUsed_success() throws IncompleteCommandException {
+//        ArrayList<String> testArrayList = new ArrayList<>(Arrays.asList(
+//                "s/S1404115ASF", "n/Speaker B", "n/Speaker A"));
+//        UpdateCommand expectedCommand = new UpdateCommand(new ArrayList<>(
+//                Arrays.asList("s/S1404115ASF", "n/Speaker A")
+//        ));
+//        UpdateCommand actualCommand = new UpdateCommand(testArrayList);
+//        actualCommand.prepareModification();
+//        assertEquals(expectedCommand, actualCommand);
+//    }
 }


### PR DESCRIPTION
Added support for tags being in any order for AddCommand. 

I noticed that @Bryan-BC updated the parameters for EquipmentManager.addEquipment() to accept the equipment object itself instead of the equipment's individual attributes. I followed this updated parameters and so there will likely be error until both of our pull requests get merged.