### PR TITLE
Support parsing of capitalised commands, enumeration and argument tags

### DIFF
--- a/src/main/java/seedu/command/IncorrectCommand.java
+++ b/src/main/java/seedu/command/IncorrectCommand.java
@@ -17,8 +17,28 @@ public class IncorrectCommand extends Command {
         return new CommandResult(feedbackToUser);
     }
 
-    public boolean equals(IncorrectCommand other) {
-        return feedbackToUser.equals(other.feedbackToUser);
+    /**
+     * Implement equals for JUnit comparisons
+     * Source: https://www.geeksforgeeks.org/overriding-equals-method-in-java/
+     * @param o Any object
+     * @return If two commands are the same
+     */
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+
+        /* Check if o is an instance of IncorrectCommand or not
+          "null instanceof [type]" also returns false */
+        if (!(o instanceof IncorrectCommand)) {
+            return false;
+        }
+
+        // typecast o to IncorrectCommand so that we can compare data members
+        IncorrectCommand c = (IncorrectCommand) o;
+
+        // Compare the data members and return accordingly
+        return this.feedbackToUser.equals(c.feedbackToUser);
     }
 
 }

--- a/src/main/java/seedu/parser/Parser.java
+++ b/src/main/java/seedu/parser/Parser.java
@@ -67,7 +67,7 @@ public class Parser {
         switch (commandAndArgument.get(0)) {
         case AddCommand.COMMAND_WORD:
             try {
-                args = prepareAdd(commandAndArgument.get(1));
+                args = extractArguments(commandAndArgument.get(1));
                 return new AddCommand(args);
             } catch (IncompleteCommandException e) {
                 return new IncorrectCommand(AddCommand.COMMAND_WORD + AddCommand.COMMAND_DESCRIPTION);

--- a/src/main/java/seedu/parser/Parser.java
+++ b/src/main/java/seedu/parser/Parser.java
@@ -12,6 +12,7 @@ import seedu.command.HelpCommand;
 import seedu.command.Command;
 
 import java.util.Collections;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -120,22 +121,26 @@ public class Parser {
     public ArrayList<String> splitCommandTerm(String userInput) throws IncompleteCommandException {
         ArrayList<String> resultArrayList = new ArrayList<>();
         userInput = userInput.trim();
-        if (userInput.equals(ListCommand.COMMAND_WORD)) {
-            resultArrayList.add("list");
+        // Checks for "list" command word first
+        if (userInput.toLowerCase(Locale.ROOT).equals(ListCommand.COMMAND_WORD)) {
+            resultArrayList.add(ListCommand.COMMAND_WORD);
             resultArrayList.add(null);
             return resultArrayList;
         }
-        if (userInput.equals(HelpCommand.COMMAND_WORD)) {
-            resultArrayList.add("help");
+        // Checks for "help" command word next
+        if (userInput.toLowerCase(Locale.ROOT).equals(HelpCommand.COMMAND_WORD)) {
+            resultArrayList.add(HelpCommand.COMMAND_WORD);
             resultArrayList.add(null);
             return resultArrayList;
         }
+        // Match terms against syntax
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput);
-        // guard against no match
+        // Guard against no match
         if (!matcher.matches()) {
             throw new IncompleteCommandException("Could not find space delimiter between command and arguments!");
         }
-        resultArrayList.add(matcher.group("commandWord"));
+        // Match and return ArrayList appropriately
+        resultArrayList.add(matcher.group("commandWord").toLowerCase(Locale.ROOT));
         resultArrayList.add(matcher.group("arguments"));
         return resultArrayList;
     }

--- a/src/main/java/seedu/parser/Parser.java
+++ b/src/main/java/seedu/parser/Parser.java
@@ -237,5 +237,9 @@ public class Parser {
         return argument.contains("/");
     }
 
+    private static String setArgumentTagsToLower(String argument) {
+        int slashIndex = argument.indexOf("/");
+        return argument.substring(0, slashIndex).toUpperCase(Locale.ROOT) + argument.substring(slashIndex);
+    }
 
 }

--- a/src/main/java/seedu/parser/Parser.java
+++ b/src/main/java/seedu/parser/Parser.java
@@ -38,6 +38,7 @@ public class Parser {
     );
     public static final Pattern VIEW_COMMAND_FORMAT = Pattern.compile("[Nn]/(?<itemName>.+)");
     public static final Pattern DELETE_COMMAND_FORMAT = Pattern.compile("[Ss]/(?<serialNumber>.+)");
+    public static final Pattern TYPE_ENUM_FORMAT = Pattern.compile("[Tt]/(?<equipmentType>\\w+)");
     // ARGUMENT_FORMAT extracts first n-1 tags, for debugging: https://regex101.com/r/gwjHWD/3
     public static final Pattern MODIFICATION_ARGUMENT_FORMAT = Pattern.compile(
             "((?:[sntcSNTC]|[pP][fF]|[pP][dD])" // argument tag
@@ -170,11 +171,10 @@ public class Parser {
      *
      * <p>5. <code> purchasedDate </code>: String representation for now, possibility for future support
      *
-     * @deprecated Use extractArguments as it is more robust in conjunction with subclasses of ModificationCommand
      * @param args String to be split into substrings
      * @return ArrayList of arguments
      * @throws IncompleteCommandException if no match found
-     *
+     * @deprecated Use extractArguments as it is more robust in conjunction with subclasses of ModificationCommand
      */
     @Deprecated
     protected ArrayList<String> prepareAdd(String args) throws IncompleteCommandException {
@@ -253,6 +253,17 @@ public class Parser {
         } catch (IllegalStateException e) {
             throw new IncompleteCommandException("No parameters found!");
         }
+
+        for (int i = splitArguments.size() - 1; i >= 0; i--) {
+            String argumentPair = splitArguments.get(i);
+            Matcher matcher = TYPE_ENUM_FORMAT.matcher(argumentPair);
+            if (matcher.matches()) {
+                splitArguments.remove(argumentPair);
+                splitArguments.add("t/" + matcher.group("equipmentType").toUpperCase(Locale.ROOT));
+                return splitArguments;
+            }
+        }
+
         return splitArguments;
     }
 

--- a/src/main/java/seedu/parser/Parser.java
+++ b/src/main/java/seedu/parser/Parser.java
@@ -39,11 +39,18 @@ public class Parser {
     public static final Pattern DELETE_COMMAND_FORMAT = Pattern.compile("s/(?<itemName>.+)");
     // ARGUMENT_FORMAT extracts first n-1 tags
     public static final Pattern ARGUMENT_FORMAT = Pattern.compile(
-            "((?:s|n|t|c|pf|pd)\\/[\\w\\s\\-]+?)\\s+(?=s|n|t|c|pf|pd)"
+            "((?:s|n|t|c|pf|pd)" // argument tag
+                    + "\\/" // argument delimiter
+                    + "[\\w\\s\\-]+?)" // actual argument value
+                    + "\\s+" // argument space before next delimiter
+                    + "(?=s|n|t|c|pf|pd)" // next delimiter
     );
     // ARGUMENT_TRAILING_FORMAT extracts last tag
     public static final Pattern ARGUMENT_TRAILING_FORMAT = Pattern.compile(
-            "(?<!\\w)(?:s|n|t|c|pf|pd)\\/([\\w\\s\\-]+)"
+            "(?<!\\w)" // require a previous pattern
+                    + "(?:s|n|t|c|pf|pd)" // argument tag
+                    + "\\/" // argument delimiter
+                    + "([\\w\\s\\-]+)" // last argument value
     );
     public static final String MESSAGE_INCOMPLETE_COMMAND_MISSING_DELIMITER =
             "Please split your command into arguments with each argument seperated by spaces!";

--- a/src/main/java/seedu/parser/Parser.java
+++ b/src/main/java/seedu/parser/Parser.java
@@ -197,7 +197,7 @@ public class Parser {
         if (!matcher.matches()) {
             throw new IncompleteCommandException("View command values are incomplete or missing!");
         }
-        return new ArrayList<>(Collections.singleton(matcher.group(1)));
+        return new ArrayList<>(Collections.singleton(matcher.group("itemName")));
     }
 
     /**
@@ -212,7 +212,7 @@ public class Parser {
         if (!matcher.matches()) {
             throw new IncompleteCommandException("Delete command values are incomplete or missing!");
         }
-        return new ArrayList<>(Collections.singleton(matcher.group(1)));
+        return new ArrayList<>(Collections.singleton(matcher.group("serialNumber")));
     }
 
     /**

--- a/src/main/java/seedu/parser/Parser.java
+++ b/src/main/java/seedu/parser/Parser.java
@@ -37,7 +37,7 @@ public class Parser {
     );
     public static final Pattern VIEW_COMMAND_FORMAT = Pattern.compile("n/(?<itemName>.+)");
     public static final Pattern DELETE_COMMAND_FORMAT = Pattern.compile("s/(?<itemName>.+)");
-    // ARGUMENT_FORMAT extracts first n-1 tags
+    // ARGUMENT_FORMAT extracts first n-1 tags, for debugging: https://regex101.com/r/gwjHWD/1
     public static final Pattern ARGUMENT_FORMAT = Pattern.compile(
             "((?:s|n|t|c|pf|pd)" // argument tag
                     + "\\/" // argument delimiter

--- a/src/test/java/seedu/parser/ParserTest.java
+++ b/src/test/java/seedu/parser/ParserTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -189,7 +190,7 @@ class ParserTest {
         ));
         ArrayList<ArrayList<String>> expectedResults = new ArrayList<>();
         expectedResults.add(new ArrayList<>(Arrays.asList(
-                "s/S1404115ASF", "n/Speaker B", "t/Speaker", "c/1000", "pf/Loud Technologies", "pd/2022-02-23")));
+                "s/S1404115ASF", "n/Speaker B", "t/SPEAKER", "c/1000", "pf/Loud Technologies", "pd/2022-02-23")));
         expectedResults.add(new ArrayList<>(Arrays.asList(
                 "s/S1404115ASF", "c/1000")));
         expectedResults.add(new ArrayList<>(Arrays.asList(
@@ -197,11 +198,15 @@ class ParserTest {
         expectedResults.add(new ArrayList<>(Arrays.asList(
                 "s/S1404115ASF", "pf/Loud Technologies", "n/Speaker B")));
         expectedResults.add(new ArrayList<>(Arrays.asList(
-                "t/Speaker", "s/S1404115ASF")));
+                "t/SPEAKER", "s/S1404115ASF")));
         expectedResults.add(new ArrayList<>(Arrays.asList(
                 "c/1000", "pf/Loud Technologies", "s/S1404115ASF")));
         for (int i = 0; i < expectedResults.size(); i++) {
-            assertEquals(expectedResults.get(i), parser.extractArguments(testStrings.get(i)));
+            ArrayList<String> testResultsSorted = parser.extractArguments(testStrings.get(i));
+            ArrayList<String> expectedResultsSorted = expectedResults.get(i);
+            testResultsSorted.sort(Comparator.comparing(String::toString));
+            expectedResultsSorted.sort(Comparator.comparing(String::toString));
+            assertEquals(expectedResultsSorted, testResultsSorted);
         }
     }
 
@@ -217,7 +222,7 @@ class ParserTest {
         ));
         ArrayList<ArrayList<String>> expectedResults = new ArrayList<>();
         expectedResults.add(new ArrayList<>(Arrays.asList(
-                "s/S1404115ASF", "n/Speaker B", "t/Speaker", "c/1000", "pf/Loud Technologies", "pd/2022-02-23")));
+                "s/S1404115ASF", "n/Speaker B", "t/SPEAKER", "c/1000", "pf/Loud Technologies", "pd/2022-02-23")));
         expectedResults.add(new ArrayList<>(Arrays.asList(
                 "s/S1404115ASF", "c/1000")));
         expectedResults.add(new ArrayList<>(Arrays.asList(
@@ -225,11 +230,15 @@ class ParserTest {
         expectedResults.add(new ArrayList<>(Arrays.asList(
                 "s/S1404115ASF", "pf/Loud Technologies", "n/Speaker B")));
         expectedResults.add(new ArrayList<>(Arrays.asList(
-                "t/Speaker", "s/S1404115ASF")));
+                "t/SPEAKER", "s/S1404115ASF")));
         expectedResults.add(new ArrayList<>(Arrays.asList(
                 "c/1000", "pf/Loud Technologies", "s/S1404115ASF")));
         for (int i = 0; i < expectedResults.size(); i++) {
-            assertEquals(expectedResults.get(i), parser.extractArguments(testStrings.get(i)));
+            ArrayList<String> testResultsSorted = parser.extractArguments(testStrings.get(i));
+            ArrayList<String> expectedResultsSorted = expectedResults.get(i);
+            testResultsSorted.sort(Comparator.comparing(String::toString));
+            expectedResultsSorted.sort(Comparator.comparing(String::toString));
+            assertEquals(expectedResultsSorted, testResultsSorted);
         }
     }
 

--- a/src/test/java/seedu/parser/ParserTest.java
+++ b/src/test/java/seedu/parser/ParserTest.java
@@ -234,7 +234,7 @@ class ParserTest {
         ArrayList<String> testArrayList = new ArrayList<>(Arrays.asList(
                 "n/Speaker B", "t/Speaker", "c/1000", "pf/Loud Technologies", "pd/2022-02-23"));
         IncorrectCommand expectedCommand = new IncorrectCommand("Serial Number is required to update an item!");
-        assertEquals(expectedCommand, parser.prepareUpdate(testArrayList));
+        assertTrue(expectedCommand.equals(parser.prepareUpdate(testArrayList)));
     }
 
     @Test
@@ -245,7 +245,7 @@ class ParserTest {
         UpdateCommand expectedCommand = new UpdateCommand();
         expectedCommand.setSerialNumber("S1404115ASF");
         expectedCommand.setType("Speaker A");
-        assertEquals(expectedCommand, parser.prepareUpdate(testArrayList));
+        assertTrue(expectedCommand.equals(parser.prepareUpdate(testArrayList)));
     }
 
 }

--- a/src/test/java/seedu/parser/ParserTest.java
+++ b/src/test/java/seedu/parser/ParserTest.java
@@ -1,15 +1,11 @@
 package seedu.parser;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import seedu.command.IncorrectCommand;
-import seedu.command.UpdateCommand;
 
-import java.sql.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -51,6 +47,8 @@ class ParserTest {
         }
     }
 
+    @Deprecated
+    @Disabled("extractArgument is a better replacement for prepareAdd")
     @Test
     void prepareAdd_addStringWithSpaces_success() throws IncompleteCommandException {
         ArrayList<String> expectedResult = new ArrayList<>(
@@ -61,6 +59,8 @@ class ParserTest {
         assertEquals(expectedResult, actualResult);
     }
 
+    @Deprecated
+    @Disabled("extractArgument is a better replacement for prepareAdd")
     @Test
     void prepareAdd_insufficientArguments_exceptionThrown() {
         ArrayList<String> unexpectedResult = new ArrayList<>(
@@ -76,6 +76,8 @@ class ParserTest {
         }
     }
 
+    @Deprecated
+    @Disabled("extractArgument is a better replacement for prepareAdd")
     @Test
     void prepareAdd_argumentEnteredTwice_exceptionThrown() {
         ArrayList<String> unexpectedResult = new ArrayList<>(
@@ -91,6 +93,8 @@ class ParserTest {
         }
     }
 
+    @Deprecated
+    @Disabled("extractArgument is a better replacement for prepareAdd")
     @Test
     void prepareAdd_argumentIncludesSlashA_exceptionThrown() {
         ArrayList<String> unexpectedResult = new ArrayList<>(
@@ -106,6 +110,8 @@ class ParserTest {
         }
     }
 
+    @Deprecated
+    @Disabled("extractArgument is a better replacement for prepareAdd")
     @Test
     void prepareAdd_argumentIncludesSlashB_exceptionThrown() {
         ArrayList<String> unexpectedResult = new ArrayList<>(
@@ -180,6 +186,34 @@ class ParserTest {
                 "s/S1404115ASF pf/Loud Technologies n/Speaker B",
                 "t/Speaker s/S1404115ASF",
                 "c/1000 pf/Loud Technologies s/S1404115ASF"
+        ));
+        ArrayList<ArrayList<String>> expectedResults = new ArrayList<>();
+        expectedResults.add(new ArrayList<>(Arrays.asList(
+                "s/S1404115ASF", "n/Speaker B", "t/Speaker", "c/1000", "pf/Loud Technologies", "pd/2022-02-23")));
+        expectedResults.add(new ArrayList<>(Arrays.asList(
+                "s/S1404115ASF", "c/1000")));
+        expectedResults.add(new ArrayList<>(Arrays.asList(
+                "s/S1404115ASF", "n/Speaker B")));
+        expectedResults.add(new ArrayList<>(Arrays.asList(
+                "s/S1404115ASF", "pf/Loud Technologies", "n/Speaker B")));
+        expectedResults.add(new ArrayList<>(Arrays.asList(
+                "t/Speaker", "s/S1404115ASF")));
+        expectedResults.add(new ArrayList<>(Arrays.asList(
+                "c/1000", "pf/Loud Technologies", "s/S1404115ASF")));
+        for (int i = 0; i < expectedResults.size(); i++) {
+            assertEquals(expectedResults.get(i), parser.extractArguments(testStrings.get(i)));
+        }
+    }
+
+    @Test
+    void extractArguments_mixedCaseText_success() throws IncompleteCommandException {
+        ArrayList<String> testStrings = new ArrayList<>(Arrays.asList(
+                "S/S1404115ASF n/Speaker B t/Speaker c/1000 Pf/Loud Technologies PD/2022-02-23",
+                "s/S1404115ASF     C/1000",
+                "s/S1404115ASF N/Speaker B        ",
+                "s/S1404115ASF pf/Loud Technologies n/Speaker B",
+                "t/Speaker S/S1404115ASF",
+                "c/1000 pF/Loud Technologies s/S1404115ASF"
         ));
         ArrayList<ArrayList<String>> expectedResults = new ArrayList<>();
         expectedResults.add(new ArrayList<>(Arrays.asList(


### PR DESCRIPTION
All combinations of capitalised/uncapitalised elements (command word, enumeration, argument tags) are now supported while retaining the case sensitivity of argument values.

Example:
`aDD N/SpeakerB s/S1404115ASF t/speaker C/1000 pf/Loud Technologies pd/2022-02-23` will be parsed (create AddCommand) exactly as `add n/SpeakerB s/S1404115ASF t/SPEAKER C/1000 pf/Loud_Technologies pd/2022-02-23`.

resolves #47 