### PR TITLE
Add support for decimal costs in Parser

### DIFF
--- a/src/main/java/seedu/parser/Parser.java
+++ b/src/main/java/seedu/parser/Parser.java
@@ -30,6 +30,27 @@ public class Parser {
      * passed into arguments.
      */
     public static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)\\s+(?<arguments>.+)");
+    public static final Pattern CHECK_COMMAND_FORMAT = Pattern.compile("[Nn]/(?<itemName>.+)\\s*");
+    public static final Pattern DELETE_COMMAND_FORMAT = Pattern.compile("[Ss]/(?<serialNumber>.+)\\s*");
+    public static final Pattern TYPE_ENUM_FORMAT = Pattern.compile("[Tt]/(?<equipmentType>\\w+)\\s*");
+    // ARGUMENT_FORMAT extracts first n-1 tags, for debugging: https://regex101.com/r/7rho4H/1
+    public static final Pattern MODIFICATION_ARGUMENT_FORMAT = Pattern.compile(
+            "((?:[sntcSNTC]|[pP][fF]|[pP][dD])" // argument tag
+                    + "\\/" // argument delimiter
+                    + "[\\w\\s\\-\\.]+)" // actual argument value
+                    + "\\s+" // argument space before next delimiter
+                    + "(?=[sntcSNTC]|[pP][fF]|[pP][dD])" // next delimiter
+    );
+    // ARGUMENT_TRAILING_FORMAT extracts last tag
+    public static final Pattern MODIFICATION_ARGUMENT_TRAILING_FORMAT = Pattern.compile(
+            "(?<!\\w)" // require a previous pattern
+                    + "(?:[sntcSNTC]|[pP][fF]|[pP][dD])" // argument tag
+                    + "\\/" // argument delimiter
+                    + "([\\w\\s\\-\\.]+)" // last argument value
+    );
+    public static final String MESSAGE_INCOMPLETE_COMMAND_MISSING_DELIMITER =
+            "Please split your command into arguments with each argument seperated by spaces!";
+    public static final String INCORRECT_COMMAND_FORMAT = "Incorrect Command format! Enter help for more information.";
     @Deprecated
     public static final Pattern ADD_COMMAND_FORMAT = Pattern.compile(
             "n\\/(?<itemName>.+)" + "\\s+"
@@ -39,27 +60,6 @@ public class Parser {
                     + "pf\\/(?<purchasedFrom>.+)" + "\\s+"
                     + "pd\\/(?<purchasedDate>.+)"
     );
-    public static final Pattern CHECK_COMMAND_FORMAT = Pattern.compile("[Nn]/(?<itemName>.+)\\s*");
-    public static final Pattern DELETE_COMMAND_FORMAT = Pattern.compile("[Ss]/(?<serialNumber>.+)\\s*");
-    public static final Pattern TYPE_ENUM_FORMAT = Pattern.compile("[Tt]/(?<equipmentType>\\w+)\\s*");
-    // ARGUMENT_FORMAT extracts first n-1 tags, for debugging: https://regex101.com/r/gwjHWD/3
-    public static final Pattern MODIFICATION_ARGUMENT_FORMAT = Pattern.compile(
-            "((?:[sntcSNTC]|[pP][fF]|[pP][dD])" // argument tag
-                    + "\\/" // argument delimiter
-                    + "[\\w\\s\\-]+)" // actual argument value
-                    + "\\s+" // argument space before next delimiter
-                    + "(?=[sntcSNTC]|[pP][fF]|[pP][dD])" // next delimiter
-    );
-    // ARGUMENT_TRAILING_FORMAT extracts last tag
-    public static final Pattern MODIFICATION_ARGUMENT_TRAILING_FORMAT = Pattern.compile(
-            "(?<!\\w)" // require a previous pattern
-                    + "(?:[sntcSNTC]|[pP][fF]|[pP][dD])" // argument tag
-                    + "\\/" // argument delimiter
-                    + "([\\w\\s\\-]+)" // last argument value
-    );
-    public static final String MESSAGE_INCOMPLETE_COMMAND_MISSING_DELIMITER =
-            "Please split your command into arguments with each argument seperated by spaces!";
-    public static final String INCORRECT_COMMAND_FORMAT = "Incorrect Command format! Enter help for more information.";
 
     /**
      * Interpret the command requested by the user and returns a corresponding Command object.

--- a/src/test/java/seedu/parser/ParserTest.java
+++ b/src/test/java/seedu/parser/ParserTest.java
@@ -187,7 +187,7 @@ class ParserTest {
     void extractArguments_validCommands_success() throws IncompleteCommandException {
         ArrayList<String> testStrings = new ArrayList<>(Arrays.asList(
                 "s/S1404115ASF n/Speaker B t/Speaker c/1000 pf/Loud Technologies pd/2022-02-23",
-                "s/S1404115ASF     c/1000",
+                "s/S1404115ASF     c/1000.3",
                 "s/S1404115ASF n/Speaker B        ",
                 "s/S1404115ASF pf/Loud Technologies n/Speaker B",
                 "t/Speaker s/S1404115ASF",
@@ -197,7 +197,7 @@ class ParserTest {
         expectedResults.add(new ArrayList<>(Arrays.asList(
                 "s/S1404115ASF", "n/Speaker B", "t/SPEAKER", "c/1000", "pf/Loud Technologies", "pd/2022-02-23")));
         expectedResults.add(new ArrayList<>(Arrays.asList(
-                "s/S1404115ASF", "c/1000")));
+                "s/S1404115ASF", "c/1000.3")));
         expectedResults.add(new ArrayList<>(Arrays.asList(
                 "s/S1404115ASF", "n/Speaker B")));
         expectedResults.add(new ArrayList<>(Arrays.asList(


### PR DESCRIPTION
Included matching of "."in regex to support decimal costs.

closes #100