### PR TITLE
Remove for loop in CheckCommand#generateCheckPair

### DIFF
--- a/src/main/java/seedu/command/CheckCommand.java
+++ b/src/main/java/seedu/command/CheckCommand.java
@@ -51,35 +51,34 @@ public class CheckCommand extends Command {
     public Pair<String, ?> generateCheckPair() throws AssertionError, NumberFormatException, IllegalArgumentException {
         Pair<String, ?> pair = null;
 
-        for (String s : commandStrings) {
-            int delimiterPos = s.indexOf('/');
-            // the case where delimiterPos = -1 is impossible as
-            // ARGUMENT_FORMAT and ARGUMENT_TRAILING_FORMAT regex requires a '/'
-            assert delimiterPos != -1 : "Each args will need to include minimally a '/' to split arg and value upon";
-            String argType = s.substring(0, delimiterPos);
-            String argValue = s.substring(delimiterPos + 1);
-            switch (argType) {
-            case "n":
-                pair = new Pair<>("itemName", argValue);
-                break;
-            case "pd":
-                pair = new Pair<>("purchasedDate", argValue);
-                break;
-            case "t":
-                pair = new Pair<>("type", EquipmentType.valueOf(argValue.toUpperCase(Locale.ROOT)));
-                break;
-            case "pf":
-                pair = new Pair<>("purchasedFrom", argValue);
-                break;
-            case "c":
-                pair = new Pair<>("cost", Double.valueOf(argValue));
-                break;
-            case "s":
-                pair = new Pair<>("serialNumber", argValue);
-                break;
-            default:
-                System.out.println("`" + argValue + "` not accepted for type " + argType + ": Unrecognised Tag");
-            }
+        String s = commandStrings.get(0);
+        int delimiterPos = s.indexOf('/');
+        // the case where delimiterPos = -1 is impossible as
+        // ARGUMENT_FORMAT and ARGUMENT_TRAILING_FORMAT regex requires a '/'
+        assert delimiterPos != -1 : "Each args will need to include minimally a '/' to split arg and value upon";
+        String argType = s.substring(0, delimiterPos);
+        String argValue = s.substring(delimiterPos + 1);
+        switch (argType) {
+        case "n":
+            pair = new Pair<>("itemName", argValue);
+            break;
+        case "pd":
+            pair = new Pair<>("purchasedDate", argValue);
+            break;
+        case "t":
+            pair = new Pair<>("type", EquipmentType.valueOf(argValue.toUpperCase(Locale.ROOT)));
+            break;
+        case "pf":
+            pair = new Pair<>("purchasedFrom", argValue);
+            break;
+        case "c":
+            pair = new Pair<>("cost", Double.valueOf(argValue));
+            break;
+        case "s":
+            pair = new Pair<>("serialNumber", argValue);
+            break;
+        default:
+            System.out.println("`" + argValue + "` not accepted for type " + argType + ": Unrecognised Tag");
         }
 
         return pair;


### PR DESCRIPTION
The for loop in CheckCommand#generateCheckPair is not needed as only one attribute is expected for each CheckCommand.